### PR TITLE
Cut By Mask is always adding +1 pixel to the width and height.

### DIFF
--- a/MaskNodes.py
+++ b/MaskNodes.py
@@ -725,8 +725,8 @@ class CutByMask:
         max_x = boxes[:,2]
         max_y = boxes[:,3]
 
-        width = max_x - min_x + 1
-        height = max_y - min_y + 1
+        width = max_x - min_x
+        height = max_y - min_y
 
         use_width = int(torch.max(width).item())
         use_height = int(torch.max(height).item())


### PR DESCRIPTION
When doing a Cut by Mask, the +1 was always adding one pixel to the width and height of the output. It's a problem for example if you're trying to do multiples of 8 sizes so that the ksampler doesnt not resize the output to the nearest factor of 8.

I have an example thread on reddit about the issue: 
- [Thread](https://www.reddit.com/r/StableDiffusion/comments/15xfa9h/is_there_a_vae_encode_vae_decode_limitation_on/jx8707y/?context=3)
- [Diagram](https://www.reddit.com/media?url=https%3A%2F%2Fpreview.redd.it%2Fnn8j57v20ljb1.png%3Fwidth%3D2130%26format%3Dpng%26auto%3Dwebp%26s%3D36837cc0749e5e74a36326dc827bcc526d38b028)